### PR TITLE
Modularise csproj in to reusable property groups

### DIFF
--- a/DuplicateAssemblyScanner/.editorconfig
+++ b/DuplicateAssemblyScanner/.editorconfig
@@ -80,7 +80,7 @@ resharper_web_config_wrong_module_highlighting=warning
 trim_trailing_whitespace=true
 insert_final_newline=false
 
-[{*.csproj,*.targets}]
+[{*.csproj,*.targets,*.props}]
 indent_style=space
 indent_size=2
 tab_width=2

--- a/DuplicateAssemblyScanner/.editorconfig
+++ b/DuplicateAssemblyScanner/.editorconfig
@@ -80,13 +80,14 @@ resharper_web_config_wrong_module_highlighting=warning
 trim_trailing_whitespace=true
 insert_final_newline=false
 
+[{*.csproj,*.targets}]
+indent_style=space
+indent_size=2
+tab_width=2
+
 [*.config]
 indent_style=space
 indent_size=4
-
-[{*.csproj,*.ccproj,*.androidproj}]
-indent_style=space
-indent_size=2
 
 [*.ruleset]
 indent_style=space

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/DuplicateAssemblyScanner.csproj
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/DuplicateAssemblyScanner.csproj
@@ -1,6 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="ExternalPaths.props" Condition="Exists('ExternalPaths.props')"/>
+  <Import Project="ManagedDlls.props" Condition="Exists('ManagedDlls.props')"/>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -13,6 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
     <LangVersion>latest</LangVersion>
+    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +25,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,66 +33,7 @@
     <DefineConstants>RELEASE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <SteamPath>~/Library/Application Support/Steam/</SteamPath>
-    <SteamPath Condition="! Exists ('$(SteamPath)')">$(ProgramFiles)\Steam</SteamPath>
-    <SteamPath Condition="! Exists ('$(SteamPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)</SteamPath>
-    <CSPath>$(SteamPath)\steamapps\common\Cities_Skylines</CSPath>
-    <ManagedDllPath>$(CSPath)\Cities_Data\Managed</ManagedDllPath>
-    <ManagedDllPath Condition="! Exists ('$(ManagedDllPath)')">..\dependencies</ManagedDllPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\ColossalManaged.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\ICities.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(ManagedDllPath)\System.Configuration.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(ManagedDllPath)\System.Security.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.Networking.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
@@ -113,28 +56,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-        set _CslDir=%LOCALAPPDATA%\Colossal Order\Cities_Skylines
-        set _ModDir=%_CslDir%\Addons\Mods\$(SolutionName)
-
-        echo.
-        echo ManagedDllPath = $(ManagedDllPath)
-        echo.
-        echo _CslDir = %_CslDir%
-        echo _ModDir = %_ModDir%
-        echo.
-
-        mkdir "%_ModDir%"
-
-        rem If in-game, this will trigger a hot-reload of the mod.
-        if exist "%_ModDir%\$(TargetFileName)" (
-          del "%_ModDir%\$(TargetFileName)"
-        )
-        xcopy "$(TargetDir)$(TargetFileName)" "%_ModDir%" /y /e
-
-        set _CslDir=
-        set _ModDir=
-      </PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="PostBuild.props" Condition="Exists('PostBuild.props')"/>
 </Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ExternalPaths.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ExternalPaths.props
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">~/Library/Application Support/Colossal Order/Cities_Skylines</_LocalPath>
+        <!-- Mac -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Mac</_DevPlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">~/.local/share/Colossal Order/Cities_Skylines</_LocalPath>
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">$(XDG_DATA_HOME)/Colossal Order/Cities_Skylines</_LocalPath>
+        <!-- Linux -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Linux</_DevPlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath>$(LocalAppData)\Colossal Order\Cities_Skylines</_LocalPath>
+        <!-- Windows -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Win</_DevPlatform>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Mac'">
+        <_MacAppPath>Cities_Skylines/Cities.app</_MacAppPath>
+        <!-- Portal: Steam -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">~/Library/Application Support/Steam/steamapps/common/$(_MacAppPath)</_CslPath>
+        <!-- Portal: Origin -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">~/Library/Application Support/Origin/$(_MacAppPath)</_CslPath>
+        <!-- Managed .dll folder -->
+        <ManagedDllPath Condition="Exists ('$(_CslPath)')">$(_CslPath)/Contents/Resources/Data/Managed</ManagedDllPath>
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">/Addons/Mods/$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Linux'">
+        <!-- Portal: Steam -->
+        <!-- todo -->
+        <!-- Managed .dll folder -->
+        <!-- todo -->
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">/Addons/Mods/$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Win'">
+        <!-- Portal: Steam -->
+        <_SteamAppPath>steamapps\common\Cities_Skylines</_SteamAppPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Steam\$(_SteamAppPath)</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\$(_SteamAppPath)</_CslPath>
+        <!-- Portal: EA Origin -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Origin Games\Cities_Skylines</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Origin\Cities_Skylines</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\$(_SteamAppPath)</_CslPath>
+        <!-- Managed .dll folder -->
+        <ManagedDllPath Condition="Exists ('$(_CslPath)')">$(_CslPath)\Cities_Data\Managed</ManagedDllPath>
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">$(_LocalPath)\Addons\Mods\$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManagedDllPath Condition="! Exists ('$(ManagedDllPath)')">..\dependencies</ManagedDllPath>
+    </PropertyGroup>
+</Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ManagedDlls.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ManagedDlls.props
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+      <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\Assembly-CSharp.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\ColossalManaged.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\ICities.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\mscorlib.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <HintPath>$(ManagedDllPath)\System.Configuration.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.Core.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <HintPath>$(ManagedDllPath)\System.Security.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.Xml.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.Networking.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.UI.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/PostBuild.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/PostBuild.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+      <PostBuildEvent>
+            echo.
+            echo _DevPlatform   = $(_DevPlatform)
+            echo.
+            echo _CslPath       = $(_CslPath)
+            echo ManagedDllPath = $(ManagedDllPath)
+            echo.
+            echo _LocalPath     = $(_LocalPath)
+            echo PublishDllPath = $(PublishDllPath)
+            echo.
+
+            if not exist "$(PublishDllPath)\" (
+                mkdir "$(PublishDllPath)"
+            )
+
+            rem If in-game, this will trigger a hot-reload of the mod.
+            if exist "$(PublishDllPath)\$(TargetFileName)" (
+                del "$(PublishDllPath)\$(TargetFileName)"
+            )
+            xcopy "$(TargetDir)$(TargetFileName)" "$(PublishDllPath)" /y /f
+        </PostBuildEvent>
+    </PropertyGroup>
+
+</Project>


### PR DESCRIPTION
Some common properties are used across multiple mods; they should be split out to allow centralised updates.

- External paths: `Managed` dlls and `Addons/Mods`
    - Auto-determine for Windows (full support), Mac (partial support) and Linux (limited support)
- Managed DLL files
    - Use determined `Managed` dll path
    - File will undergo further revisions at later date
- Post build script
    - Using auto-generated paths and filenames