### PR TITLE
Update Log.cs, Settings.cs and UserMod.cs

### DIFF
--- a/DuplicateAssemblyScanner/.editorconfig
+++ b/DuplicateAssemblyScanner/.editorconfig
@@ -80,7 +80,7 @@ resharper_web_config_wrong_module_highlighting=warning
 trim_trailing_whitespace=true
 insert_final_newline=false
 
-[{*.csproj,*.targets}]
+[{*.csproj,*.targets,*.props}]
 indent_style=space
 indent_size=2
 tab_width=2

--- a/DuplicateAssemblyScanner/.editorconfig
+++ b/DuplicateAssemblyScanner/.editorconfig
@@ -80,13 +80,14 @@ resharper_web_config_wrong_module_highlighting=warning
 trim_trailing_whitespace=true
 insert_final_newline=false
 
+[{*.csproj,*.targets}]
+indent_style=space
+indent_size=2
+tab_width=2
+
 [*.config]
 indent_style=space
 indent_size=4
-
-[{*.csproj,*.ccproj,*.androidproj}]
-indent_style=space
-indent_size=2
 
 [*.ruleset]
 indent_style=space

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/DuplicateAssemblyScanner.csproj
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/DuplicateAssemblyScanner.csproj
@@ -1,6 +1,8 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <Import Project="$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props" Condition="Exists('$(MSBuildExtensionsPath)\$(MSBuildToolsVersion)\Microsoft.Common.props')" />
+  <Import Project="ExternalPaths.props" Condition="Exists('ExternalPaths.props')"/>
+  <Import Project="ManagedDlls.props" Condition="Exists('ManagedDlls.props')"/>
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <Platform Condition=" '$(Platform)' == '' ">AnyCPU</Platform>
@@ -13,6 +15,7 @@
     <FileAlignment>512</FileAlignment>
     <Deterministic>false</Deterministic>
     <LangVersion>latest</LangVersion>
+    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>
@@ -22,7 +25,6 @@
     <DefineConstants>DEBUG;TRACE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>pdbonly</DebugType>
@@ -31,66 +33,7 @@
     <DefineConstants>RELEASE</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
-    <CodeAnalysisRuleSet>..\CodeAnalysis.ruleset</CodeAnalysisRuleSet>
   </PropertyGroup>
-  <PropertyGroup>
-    <SteamPath>~/Library/Application Support/Steam/</SteamPath>
-    <SteamPath Condition="! Exists ('$(SteamPath)')">$(ProgramFiles)\Steam</SteamPath>
-    <SteamPath Condition="! Exists ('$(SteamPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)</SteamPath>
-    <CSPath>$(SteamPath)\steamapps\common\Cities_Skylines</CSPath>
-    <ManagedDllPath>$(CSPath)\Cities_Data\Managed</ManagedDllPath>
-    <ManagedDllPath Condition="! Exists ('$(ManagedDllPath)')">..\dependencies</ManagedDllPath>
-  </PropertyGroup>
-  <ItemGroup>
-    <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\Assembly-CSharp.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\ColossalManaged.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\ICities.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\mscorlib.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(ManagedDllPath)\System.Configuration.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.Core.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
-      <HintPath>$(ManagedDllPath)\System.Security.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
-      <HintPath>$(ManagedDllPath)\System.Xml.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.Networking.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-    <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
-      <HintPath>$(ManagedDllPath)\UnityEngine.UI.dll</HintPath>
-      <Private>False</Private>
-    </Reference>
-  </ItemGroup>
   <ItemGroup>
     <Compile Include="..\VersionInfo.cs">
       <Link>Properties\VersionInfo.cs</Link>
@@ -113,28 +56,5 @@
     <None Include="packages.config" />
   </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
-  <PropertyGroup>
-    <PostBuildEvent>
-        set _CslDir=%LOCALAPPDATA%\Colossal Order\Cities_Skylines
-        set _ModDir=%_CslDir%\Addons\Mods\$(SolutionName)
-
-        echo.
-        echo ManagedDllPath = $(ManagedDllPath)
-        echo.
-        echo _CslDir = %_CslDir%
-        echo _ModDir = %_ModDir%
-        echo.
-
-        mkdir "%_ModDir%"
-
-        rem If in-game, this will trigger a hot-reload of the mod.
-        if exist "%_ModDir%\$(TargetFileName)" (
-          del "%_ModDir%\$(TargetFileName)"
-        )
-        xcopy "$(TargetDir)$(TargetFileName)" "%_ModDir%" /y /e
-
-        set _CslDir=
-        set _ModDir=
-      </PostBuildEvent>
-  </PropertyGroup>
+  <Import Project="PostBuild.props" Condition="Exists('PostBuild.props')"/>
 </Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ExternalPaths.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ExternalPaths.props
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">~/Library/Application Support/Colossal Order/Cities_Skylines</_LocalPath>
+        <!-- Mac -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Mac</_DevPlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">~/.local/share/Colossal Order/Cities_Skylines</_LocalPath>
+        <_LocalPath Condition="! Exists ('$(_LocalPath)')">$(XDG_DATA_HOME)/Colossal Order/Cities_Skylines</_LocalPath>
+        <!-- Linux -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Linux</_DevPlatform>
+    </PropertyGroup>
+    <PropertyGroup Condition="'$(_DevPlatform)' == ''">
+        <_LocalPath>$(LocalAppData)\Colossal Order\Cities_Skylines</_LocalPath>
+        <!-- Windows -->
+        <_DevPlatform Condition="Exists ('$(_LocalPath)')">Win</_DevPlatform>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Mac'">
+        <_MacAppPath>Cities_Skylines/Cities.app</_MacAppPath>
+        <!-- Portal: Steam -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">~/Library/Application Support/Steam/steamapps/common/$(_MacAppPath)</_CslPath>
+        <!-- Portal: Origin -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">~/Library/Application Support/Origin/$(_MacAppPath)</_CslPath>
+        <!-- Managed .dll folder -->
+        <ManagedDllPath Condition="Exists ('$(_CslPath)')">$(_CslPath)/Contents/Resources/Data/Managed</ManagedDllPath>
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">/Addons/Mods/$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Linux'">
+        <!-- Portal: Steam -->
+        <!-- todo -->
+        <!-- Managed .dll folder -->
+        <!-- todo -->
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">/Addons/Mods/$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup Condition="'$(_DevPlatform)' == 'Win'">
+        <!-- Portal: Steam -->
+        <_SteamAppPath>steamapps\common\Cities_Skylines</_SteamAppPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Steam\$(_SteamAppPath)</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\$(_SteamAppPath)</_CslPath>
+        <!-- Portal: EA Origin -->
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Origin Games\Cities_Skylines</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(ProgramFiles)\Origin\Cities_Skylines</_CslPath>
+        <_CslPath Condition="! Exists ('$(_CslPath)')">$(Registry:HKEY_CURRENT_USER\Software\Valve\Steam@SteamPath)\$(_SteamAppPath)</_CslPath>
+        <!-- Managed .dll folder -->
+        <ManagedDllPath Condition="Exists ('$(_CslPath)')">$(_CslPath)\Cities_Data\Managed</ManagedDllPath>
+        <!-- Publish to folder` -->
+        <PublishDllPath Condition="Exists ('$(_LocalPath)')">$(_LocalPath)\Addons\Mods\$(SolutionName)</PublishDllPath>
+    </PropertyGroup>
+
+    <PropertyGroup>
+        <ManagedDllPath Condition="! Exists ('$(ManagedDllPath)')">..\dependencies</ManagedDllPath>
+    </PropertyGroup>
+</Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ManagedDlls.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/ManagedDlls.props
@@ -1,0 +1,55 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <ItemGroup>
+      <Reference Include="Assembly-CSharp, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\Assembly-CSharp.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="ColossalManaged, Version=0.3.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\ColossalManaged.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="ICities, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\ICities.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="mscorlib, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\mscorlib.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Configuration, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <HintPath>$(ManagedDllPath)\System.Configuration.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Core, Version=3.5.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.Core.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Security, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
+        <HintPath>$(ManagedDllPath)\System.Security.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="System.Xml, Version=2.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+        <HintPath>$(ManagedDllPath)\System.Xml.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine, Version=0.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.Networking, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.Networking.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+      <Reference Include="UnityEngine.UI, Version=1.0.0.0, Culture=neutral, PublicKeyToken=null">
+        <HintPath>$(ManagedDllPath)\UnityEngine.UI.dll</HintPath>
+        <Private>False</Private>
+      </Reference>
+    </ItemGroup>
+
+</Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/PostBuild.props
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/PostBuild.props
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Project ToolsVersion="15.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+    <PropertyGroup>
+      <PostBuildEvent>
+            echo.
+            echo _DevPlatform   = $(_DevPlatform)
+            echo.
+            echo _CslPath       = $(_CslPath)
+            echo ManagedDllPath = $(ManagedDllPath)
+            echo.
+            echo _LocalPath     = $(_LocalPath)
+            echo PublishDllPath = $(PublishDllPath)
+            echo.
+
+            if not exist "$(PublishDllPath)\" (
+                mkdir "$(PublishDllPath)"
+            )
+
+            rem If in-game, this will trigger a hot-reload of the mod.
+            if exist "$(PublishDllPath)\$(TargetFileName)" (
+                del "$(PublishDllPath)\$(TargetFileName)"
+            )
+            xcopy "$(TargetDir)$(TargetFileName)" "$(PublishDllPath)" /y /f
+        </PostBuildEvent>
+    </PropertyGroup>
+
+</Project>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/Settings.cs
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/Settings.cs
@@ -10,15 +10,31 @@ namespace DuplicateAssemblyScanner {
     /// Generates the settings screen based on cached results from the assembly scanner.
     /// </summary>
     public class Settings {
+        /// <summary>
+        /// Cache the number of duplicates per assembly name.
+        ///
+        /// Setting this to <c>null</c> causes a fresh scan next time
+        /// <c>Settings.CreateUI()</c> is called.
+        /// </summary>
+        internal static Dictionary<string, int> _duplicates;
+
         // Markers used in checkbox labels and log entries
         private const string MARKER_DOUBLEBLANK = "  ";
         private const string MARKER_BLANK = " ";
         private const string MARKER_ENABLED = "*";
         private const string MARKER_LOADED = ">";
 
-        // Cache of scan results
-        private static Dictionary<string, int> _duplicates;
+        /// <summary>
+        /// Cache which mods contain an assembly of given name.
+        ///
+        /// By default it will only list loaded assemblies, except in the case of
+        /// <c>0Harmony.dll</c> where it will also scan for unloaded assemblies.
+        /// </summary>
         private static Dictionary<string, List<ModAssembly>> _occurrences;
+
+        /// <summary>
+        /// Cache whether duplicates were found on last scan.
+        /// </summary>
         private static bool _duplicatesFound;
 
         /// <summary>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/Settings.cs
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/Settings.cs
@@ -17,9 +17,9 @@ namespace DuplicateAssemblyScanner {
         private const string MARKER_LOADED = ">";
 
         // Cache of scan results
-        private static Dictionary<string, int> duplicates_;
-        private static Dictionary<string, List<ModAssembly>> occurrences_;
-        private static bool duplicatesFound_;
+        private static Dictionary<string, int> _duplicates;
+        private static Dictionary<string, List<ModAssembly>> _occurrences;
+        private static bool _duplicatesFound;
 
         /// <summary>
         /// Generate the options screen listing all the duplicates (if found).
@@ -32,10 +32,10 @@ namespace DuplicateAssemblyScanner {
 
             if (CacheScan(out var duplicates, out var occurrences)) {
 
-                group = helper.AddGroup("Duplicate assemblies were detected.");
+                group = AddGroup("Duplicate assemblies were detected.", helper);
 
-                Disable((UICheckBox)group.AddCheckbox("= Assembly is loaded in to app domain", true, (bool _) => { }));
-                Disable((UICheckBox)group.AddCheckbox("= Assembly not loaded", false, (bool _) => { }));
+                AddCheckbox("= Assembly is loaded in to app domain", true, group);
+                AddCheckbox("= Assembly not loaded", false, group);
 
                 foreach (var duplicate in duplicates) {
 
@@ -48,7 +48,7 @@ namespace DuplicateAssemblyScanner {
                     }
                 }
             } else {
-                helper.AddGroup("No duplicates.");
+                AddGroup("No duplicates.", helper);
             }
         }
 
@@ -60,7 +60,7 @@ namespace DuplicateAssemblyScanner {
         /// <param name="assemblyName">The name of the assembly.</param>
         /// <param name="loaded">How many copies of the assembly are loaded.</param>
         /// <param name="list">The list of mods containing the assembly.</param>
-        internal static void RenderDetails(
+        private static void RenderDetails(
             UIHelperBase helper,
             string assemblyName,
             int loaded,
@@ -73,7 +73,7 @@ namespace DuplicateAssemblyScanner {
             log.Append("\n    Asm Version  MD5 Hash                         /Mod Folder   Mod name\n");
             log.Insert(log.Length, "-", 105);
 
-            UIHelperBase group = helper.AddGroup($"{assemblyName} ({loaded} loaded, {list.Count} mods):");
+            UIHelperBase group = AddGroup($"{assemblyName} ({loaded} loaded, {list.Count} mods):", helper);
 
             foreach (ModAssembly item in list) {
                 string v = item.AsmDetails.Version.ToString();
@@ -89,20 +89,20 @@ namespace DuplicateAssemblyScanner {
                     item.Folder.PadRight(12),
                     n);
 
-                Disable((UICheckBox)group.AddCheckbox($"{v} {e} {n}", item.AsmLoaded, (bool _) => { }));
+                AddCheckbox($"{v} {e} {n}", item.AsmLoaded, group);
             }
 
             Log.Info(log.ToString());
         }
 
-        /// <summary>
-        /// Disables a checkbox and sets its opacity based on state.
-        /// </summary>
-        /// 
-        /// <param name="box">The checkbox to disable.</param>
-        private static void Disable(UICheckBox box) {
+        private static UIHelperBase AddGroup(string caption, UIHelperBase parent) {
+            return parent.AddGroup(caption);
+        }
+
+        private static void AddCheckbox(string caption, bool enabled, UIHelperBase group) {
+            UICheckBox box = (UICheckBox)group.AddCheckbox(caption, enabled, (bool _) => { });
             box.readOnly = true;
-            box.opacity = box.isChecked ? 1f : 0.4f;
+            box.opacity = enabled ? 1f : 0.4f;
         }
 
         /// <summary>
@@ -117,15 +117,15 @@ namespace DuplicateAssemblyScanner {
             out Dictionary<string, int> duplicates,
             out Dictionary<string, List<ModAssembly>> occurrences) {
             
-            if (duplicates_ == null) {
-                duplicatesFound_ = Assemblies.Scan(out var dup, out var occ);
-                duplicates_ = dup;
-                occurrences_ = occ;
+            if (_duplicates == null) {
+                _duplicatesFound = Assemblies.Scan(out var dup, out var occ);
+                _duplicates = dup;
+                _occurrences = occ;
             }
 
-            duplicates = duplicates_;
-            occurrences = occurrences_;
-            return duplicatesFound_;
+            duplicates = _duplicates;
+            occurrences = _occurrences;
+            return _duplicatesFound;
         }
     }
 }

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/UserMod.cs
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/UserMod.cs
@@ -49,6 +49,9 @@ namespace DuplicateAssemblyScanner {
         /// </summary>
         public void OnModsChanged() {
             Log.Info($"[OnModsChanged] {SceneManager.GetActiveScene().name}");
+
+            // force rescan:
+            Settings._duplicates = null;
         }
 
         /// <summary>

--- a/DuplicateAssemblyScanner/DuplicateAssemblyScanner/UserMod.cs
+++ b/DuplicateAssemblyScanner/DuplicateAssemblyScanner/UserMod.cs
@@ -1,6 +1,9 @@
 namespace DuplicateAssemblyScanner {
+    using ColossalFramework;
+    using ColossalFramework.Plugins;
     using ICities;
     using JetBrains.Annotations;
+    using UnityEngine.SceneManagement;
 
     /// <summary>
     /// The main mod class which the game instantiates when the mod is enabled.
@@ -25,6 +28,9 @@ namespace DuplicateAssemblyScanner {
         [UsedImplicitly]
         public void OnEnabled() {
             Log.Debug("Enabled");
+            PluginManager plugins = Singleton<PluginManager>.instance;
+            plugins.eventPluginsChanged += OnModsChanged;
+            plugins.eventPluginsStateChanged += OnModsChanged;
         }
 
         /// <summary>
@@ -34,8 +40,15 @@ namespace DuplicateAssemblyScanner {
         /// <param name="helper">Helper for creating UI.</param>
         [UsedImplicitly]
         public void OnSettingsUI(UIHelperBase helper) {
-            Log.Info("[SettingsUI]");
+            Log.Info($"[SettingsUI] {SceneManager.GetActiveScene().name}");
             Settings.CreateUI(helper);
+        }
+
+        /// <summary>
+        /// Logs out when mods change, as they cause settings to be recreated.
+        /// </summary>
+        public void OnModsChanged() {
+            Log.Info($"[OnModsChanged] {SceneManager.GetActiveScene().name}");
         }
 
         /// <summary>
@@ -44,6 +57,9 @@ namespace DuplicateAssemblyScanner {
         [UsedImplicitly]
         public void OnDisabled() {
             Log.Debug("Disabled");
+            PluginManager plugins = Singleton<PluginManager>.instance;
+            plugins.eventPluginsChanged -= OnModsChanged;
+            plugins.eventPluginsStateChanged -= OnModsChanged;
         }
     }
 }


### PR DESCRIPTION
`Log.cs` is updated to latest version from `SequenceLogger` mod which has several minor improvements, most notably cleaner code and the ability to retain existing log files in the event of a hotload.

`Settings.cs` has minor updates to make the code a little more legible.

`UserMod.cs` is updated to log `PluginManager` events - these can trigger rebuilding of `SettingsUI` but it wasn't obvious from the log files.

When `PluginManager` events occur, invalidate cache of scanned assemblies. Next time `SettingsUI` is called it will do a fresh scan.